### PR TITLE
chore: fix compiler issue

### DIFF
--- a/backend/src/detect.rs
+++ b/backend/src/detect.rs
@@ -1966,7 +1966,7 @@ fn detect_template_single<T: ToInputArray + MatTraitConst>(
         .into_iter()
         .next()
         .ok_or(anyhow!("no match"))
-        .flatten()
+        .and_then(|x| x)
 }
 
 /// Detects multiple matches from `template` with the given BGR image `Mat`.


### PR DESCRIPTION
Was seeing

```
use of unstable library feature `result_flattening`
see issue #70142 <https://github.com/rust-lang/rust/issues/70142> for more information
add `#![feature(result_flattening)]` to the crate attributes to enable
this compiler was built on 2025-04-27; consider upgrading it if it is out of date
```

This just makes the feature stable